### PR TITLE
Rename to github.com/zmoog/es

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Elasticsearch CLI tool to access [Elasticsearch REST API](https://www.elastic.co
 
 Install this tool using Go:
 
-    go install github.com/zmoog/elasticsearch-cli@latest
+    go install github.com/zmoog/es@latest
 
 ## Usage
 

--- a/cli/cmd/cmd.go
+++ b/cli/cmd/cmd.go
@@ -3,8 +3,8 @@ package cmd
 import (
 	"github.com/spf13/cobra"
 	"github.com/zmoog/classeviva/adapters/feedback"
-	"github.com/zmoog/elasticsearch-cli/cli/cmd/docs"
-	"github.com/zmoog/elasticsearch-cli/cli/cmd/version"
+	"github.com/zmoog/es/cli/cmd/docs"
+	"github.com/zmoog/es/cli/cmd/version"
 )
 
 func Execute() {

--- a/cli/cmd/docs/index.go
+++ b/cli/cmd/docs/index.go
@@ -2,7 +2,7 @@ package docs
 
 import (
 	"github.com/spf13/cobra"
-	"github.com/zmoog/elasticsearch-cli/commands"
+	"github.com/zmoog/es/commands"
 )
 
 var (

--- a/cli/cmd/version/version.go
+++ b/cli/cmd/version/version.go
@@ -2,7 +2,7 @@ package version
 
 import (
 	"github.com/spf13/cobra"
-	"github.com/zmoog/elasticsearch-cli/commands"
+	"github.com/zmoog/es/commands"
 )
 
 func NewCommand() *cobra.Command {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/zmoog/elasticsearch-cli
+module github.com/zmoog/es
 
 go 1.20
 

--- a/main.go
+++ b/main.go
@@ -1,6 +1,6 @@
 package main
 
-import "github.com/zmoog/elasticsearch-cli/cli/cmd"
+import "github.com/zmoog/es/cli/cmd"
 
 func main() {
 	cmd.Execute()


### PR DESCRIPTION
### Motivation
<!-- Why this pull request? -->

I want a shorter name for a minor CLI tool.

### Change description
<!-- What does your code do? -->

Replace `github.com/zmoog/elasticsearch-cli` with `github.com/zmoog/es` everywhere it's needed.

### Additional Notes
<!-- Link any useful metadata: Jira task, GitHub issue, ... -->

### Reviewer checklist

* [x] PR address a single concern.
* [x] PR title and description are appropriately filled.
* [x] Changes will be merged in `main.`
* [ ] Changes are covered by tests.
* [ ] Logging is meaningful in case of troubleshooting.
* [x] Docs are updated (at least the `README.md`, if needed).
* [x] History is clean, commit messages are meaningful (see `CONTRIBUTING.md`) and are well-formatted.