### PR TITLE
Add search command that uses the low-level API

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,49 @@ You can also send documents from stdin (use `-` as the filename):
 
     cat docs.json | es docs bulk -f -
 
+### Search
+
+For searching documents in an Elasticsearch cluster, run:
+
+    $ es search my_index -q '{"query": {"match_all": {}}}' | jq
+    {
+      "took": 0,
+      "timed_out": false,
+      "_shards": {
+        "total": 1,
+        "successful": 1,
+        "skipped": 0,
+        "failed": 0
+      },
+      "hits": {
+        "total": {
+          "value": 2,
+          "relation": "eq"
+        },
+        "max_score": 1.0,
+        "hits": [
+          {
+            "_index": ".ds-logs-test-default-2025.01.08-000001",
+            "_id": "638aSJQBashsspu13aIM",
+            "_score": 1.0,
+            "_source": {
+              "name": "Maurizio Branca",
+              "@timestamp": "2025-01-08T22:48:27.659837121Z"
+            }
+          },
+          {
+            "_index": ".ds-logs-test-default-2025.01.08-000001",
+            "_id": "0X8DSJQBashsspu145t7",
+            "_score": 1.0,
+            "_source": {
+              "name": "Maurizio Branca",
+              "@timestamp": "2025-01-08T22:23:21.211245339Z"
+            }
+          }
+        ]
+      }
+    }
+
 ### Configuration
 
 You have the flexibility to set the app setting using the following methods (increasing priority):

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -37,10 +37,6 @@ var rootCmd = cobra.Command{
 			must(cmd.MarkFlagRequired("retry-on-status"))
 		}
 	},
-	// Run: func(cmd *cobra.Command, args []string) {
-	// 	feedback.Println("[" + viper.GetString("api.endpoints") + "]")
-	// 	feedback.Println("[" + viper.GetString("api.key") + "]")
-	// },
 }
 
 func Execute() {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -10,6 +10,7 @@ import (
 	"github.com/spf13/viper"
 	"github.com/zmoog/classeviva/adapters/feedback"
 	"github.com/zmoog/es/cmd/docs"
+	"github.com/zmoog/es/cmd/search"
 	"github.com/zmoog/es/cmd/version"
 )
 
@@ -36,10 +37,10 @@ var rootCmd = cobra.Command{
 			must(cmd.MarkFlagRequired("retry-on-status"))
 		}
 	},
-	Run: func(cmd *cobra.Command, args []string) {
-		feedback.Println("[" + viper.GetString("api.endpoints") + "]")
-		feedback.Println("[" + viper.GetString("api.key") + "]")
-	},
+	// Run: func(cmd *cobra.Command, args []string) {
+	// 	feedback.Println("[" + viper.GetString("api.endpoints") + "]")
+	// 	feedback.Println("[" + viper.GetString("api.key") + "]")
+	// },
 }
 
 func Execute() {
@@ -60,6 +61,7 @@ func init() {
 	rootCmd.PersistentFlags().StringP("client-ca-cert-path", "c", "", "CA certificate path")
 
 	rootCmd.AddCommand(docs.NewCommand())
+	rootCmd.AddCommand(search.NewCommand())
 	rootCmd.AddCommand(version.NewCommand())
 }
 

--- a/cmd/search/search.go
+++ b/cmd/search/search.go
@@ -6,6 +6,8 @@ import (
 	"github.com/zmoog/es/es/commands"
 )
 
+var query string
+
 func NewCommand() *cobra.Command {
 	cmd := cobra.Command{
 		Use:   "search [index or data stream]",
@@ -19,12 +21,12 @@ func NewCommand() *cobra.Command {
 
 			return runner.Run(commands.SearchCommand{
 				Index: args[0],
-				Query: cmd.Flag("query").Value.String(),
+				Query: query,
 			})
 		},
 	}
 
-	cmd.Flags().StringP("query", "q", "", "Query to search for")
+	cmd.Flags().StringVarP(&query, "query", "q", "", "Query to search for")
 	cmd.MarkFlagRequired("query")
 
 	return &cmd

--- a/cmd/search/search.go
+++ b/cmd/search/search.go
@@ -1,0 +1,31 @@
+package search
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/zmoog/es/es"
+	"github.com/zmoog/es/es/commands"
+)
+
+func NewCommand() *cobra.Command {
+	cmd := cobra.Command{
+		Use:   "search [index or data stream]",
+		Short: "Search using the low-level API",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			runner, err := es.NewRunner()
+			if err != nil {
+				return err
+			}
+
+			return runner.Run(commands.SearchCommand{
+				Index: args[0],
+				Query: cmd.Flag("query").Value.String(),
+			})
+		},
+	}
+
+	cmd.Flags().StringP("query", "q", "", "Query to search for")
+	cmd.MarkFlagRequired("query")
+
+	return &cmd
+}

--- a/es/commands/search.go
+++ b/es/commands/search.go
@@ -1,0 +1,34 @@
+package commands
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+)
+
+type SearchCommand struct {
+	Index string
+	Query string
+}
+
+func (c SearchCommand) ExecuteWith(uow UnitOfWork) error {
+	res, err := uow.Client.Search(
+		uow.Client.Search.WithIndex(c.Index),
+		uow.Client.Search.WithBody(strings.NewReader(c.Query)),
+	)
+	if err != nil {
+		return fmt.Errorf("error searching: %w", err)
+	}
+
+	defer res.Body.Close()
+
+	if res.IsError() {
+		return fmt.Errorf("error searching: %s", res.Status())
+	}
+
+	// write the body to stdout
+	io.Copy(os.Stdout, res.Body)
+
+	return nil
+}

--- a/es/runner.go
+++ b/es/runner.go
@@ -31,14 +31,13 @@ func (r Runner) Run(command commands.Command) error {
 // NewRunner creates a new runner that can execute commands.
 func NewRunner() (*Runner, error) {
 	retryBackoff := backoff.NewExponentialBackOff()
+
 	//
 	// Create the Elasticsearch client.
 	//
-
 	cfg := elasticsearch.Config{
-		Addresses: strings.Split(viper.GetString("api.endpoints"), ","),
-		APIKey:    viper.GetString("api.key"),
-		// RetryOnStatus: []int{502, 503, 504, 429},
+		Addresses:     strings.Split(viper.GetString("api.endpoints"), ","),
+		APIKey:        viper.GetString("api.key"),
 		RetryOnStatus: viper.GetIntSlice("client.retry-on-status"),
 
 		RetryBackoff: func(i int) time.Duration {


### PR DESCRIPTION
### Motivation
<!-- Why this pull request? -->

I want to search documents from the terminal using the Elastisearch low-level API.

### Change description
<!-- What does your code do? -->

Add anew `es search` command to run a query against an index or data stream. Here's an example:

```sh
$ echo '{"name": "Maurizio Branca"}' | es docs bulk -f - --index logs-test-default
Using config file: /Users/zmoog/.es/config
2025/01/08 23:48:27 Successfully indexed document
2025/01/08 23:48:27 Indexed 1 documents
2025/01/08 23:48:27 Errors: 0

$ es search logs-test-default -q '{}' | jq
Using config file: /Users/zmoog/.es/config
{
  "took": 0,
  "timed_out": false,
  "_shards": {
    "total": 1,
    "successful": 1,
    "skipped": 0,
    "failed": 0
  },
  "hits": {
    "total": {
      "value": 2,
      "relation": "eq"
    },
    "max_score": 1.0,
    "hits": [
      {
        "_index": ".ds-logs-test-default-2025.01.08-000001",
        "_id": "638aSJQBashsspu13aIM",
        "_score": 1.0,
        "_source": {
          "name": "Maurizio Branca",
          "@timestamp": "2025-01-08T22:48:27.659837121Z"
        }
      },
      {
        "_index": ".ds-logs-test-default-2025.01.08-000001",
        "_id": "0X8DSJQBashsspu145t7",
        "_score": 1.0,
        "_source": {
          "name": "Maurizio Branca",
          "@timestamp": "2025-01-08T22:23:21.211245339Z"
        }
      }
    ]
  }
}
```

### Additional Notes
<!-- Link any useful metadata: Jira task, GitHub issue, ... -->

- Closes #8

### Reviewer checklist

* [x] PR address a single concern.
* [x] PR title and description are appropriately filled.
* [x] Changes will be merged in `main.`
* [ ] Changes are covered by tests.
* [x] Logging is meaningful in case of troubleshooting.
* [x] Docs are updated (at least the `README.md`, if needed).
* [x] History is clean, commit messages are meaningful (see `CONTRIBUTING.md`) and are well-formatted.
