### PR TITLE
feat(search): Read search query from stdin

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,10 @@ For searching documents in an Elasticsearch cluster, run:
       }
     }
 
+You can also pipe the query from stdin:
+
+    echo '{"query": {"match_all": {}}}' | es search my_index
+
 ### Data Stream
 
 For deleting a data stream and its backing indices, run:


### PR DESCRIPTION
Now you can (optionally) read the search query from standard input:

```sh
echo '{"query": {"match_all": {}}}' | es search metrics-zcsazzurroreceiver.otel-default -q -
```

Or just using:

```sh
echo '{"query": {"match_all": {}}}' | es search metrics-zcsazzurroreceiver.otel-default
```

The main use case is reading complex queries stored in a file:

```sh
cat really-complex-query.json | es search metrics-zcsazzurroreceiver.otel-default
```
