### PR TITLE
Add brew upgrade instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,12 @@ Install this tool using Homebrew:
 brew install zmoog/homebrew-es/es
 ```
 
+If you already have `es` installed and want to get the latest:
+
+```sh
+brew upgrade zmoog/homebrew-es/es
+```
+
 ### Using Go
 
 Install this tool using Go:


### PR DESCRIPTION
## Summary
- Add `brew upgrade` command to the README for users who already have `es` installed via Homebrew.

## Test plan
- [x] Verify the README renders correctly on GitHub.

Made with [Cursor](https://cursor.com)